### PR TITLE
Fix element type definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-grid-system",
-  "version": "4.4.6",
+  "name": "@chalbert/react-grid-system",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/grid/Col/index.jsx
+++ b/src/grid/Col/index.jsx
@@ -87,7 +87,7 @@ export default class Col extends React.PureComponent {
     /**
      * Use your own component
      */
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    component: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/grid/Container/index.jsx
+++ b/src/grid/Container/index.jsx
@@ -46,7 +46,7 @@ export default class Container extends React.PureComponent {
     /**
      * Use your own component
      */
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+    component: PropTypes.elementType,
   };
 
   static defaultProps = {

--- a/src/grid/Row/index.jsx
+++ b/src/grid/Row/index.jsx
@@ -48,10 +48,7 @@ export default class Row extends React.PureComponent {
     /**
      * Use your own component
      */
-    component: PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.string,
-    ]),
+    component: PropTypes.elementType,
     /**
      * Whether the cols should not wrap
      */


### PR DESCRIPTION
This PR replaces propTypes definition for `component` prop with `PropTypes.elementType`. 

One benefit is to support forwardRef a a valid element type.